### PR TITLE
add Captions@Home tracker implementation for first tests

### DIFF
--- a/translate_data.py
+++ b/translate_data.py
@@ -8,13 +8,19 @@ import pandas as pd
 from datasets import load_dataset
 from transformers import M2M100Tokenizer, M2M100ForConditionalGeneration
 import torch.multiprocessing as mp
+import captionsathome as cah
 import torch
 set_verbosity_error()
 warnings.filterwarnings("ignore")
 
-DATA_DIR = 'DATA'
-if not os.path.exists(DATA_DIR):
-    os.makedirs(DATA_DIR)
+TMP_DATA_DIR = 'DATA'
+FINAL_DATA_DIR = ''
+
+if not os.path.exists(TMP_DATA_DIR):
+    os.makedirs(TMP_DATA_DIR)
+
+if not os.path.exists(FINAL_DATA_DIR):
+    os.makedirs(FINAL_DATA_DIR)
 
 if torch.cuda.is_available():
     device = torch.device("cuda")
@@ -55,7 +61,7 @@ def process_data(d, name, folder, tokenizer, model):
     d.to_parquet(f'{folder}/{name}.parquet', batch_size=10)
 
 
-def translate_part(tokenizer, model, start, end, small_dataset):
+def translate_part(tokenizer, model, start, end, small_dataset, DATA_DIR):
     '''
     Translates part of the desired dataset.
     tokenizer:transformers.PreTrainedTokenizer
@@ -64,9 +70,11 @@ def translate_part(tokenizer, model, start, end, small_dataset):
     end:int end of the range that dataset is splited
     small_dataset: part of the dataset that is being used
     '''
-    directory = f'{start}-{end}'
+    directory = DATA_DIR + f'/{start}-{end}'
+
     if not os.path.exists(directory):
         os.makedirs(directory)
+    
     part_dataset = small_dataset.select([i for i in range(start, end, 1)])
 
     # get all languages that are presented in the dataset
@@ -87,59 +95,88 @@ def translate_part(tokenizer, model, start, end, small_dataset):
         except KeyError:
             continue
     # combine all parquet files into one
-    fs = [pd.read_parquet(directory+'/'+path)
-          for path in os.listdir(directory)]
+    fs = [pd.read_parquet(directory+'/'+path) for path in os.listdir(directory)]
     pd.concat(fs).to_parquet(f'{DATA_DIR}/{start}-{end}.parquet')
     # remove the directory that is not needed anymore
     shutil.rmtree(directory)
 
 
+def worker():
+    client = cah.init(
+        url="http://cah.io.community/",
+        device_id="cluster"
+    )      
+
+    while client.jobCount() > 0 and not client.shouldDie():
+        client.newJob()
+        client.log("Processing...")
+
+        url, partition = client.tar_url.split(":")
+
+        url = url.split("/")[-1]
+        partition = int(partition) - 1
+
+        DATA_DIR = TMP_DATA_DIR + f'/{url}_{partition}'
+
+        dataset = load_dataset("laion/laion2B-multi", data_files=url)
+        shard = dataset.shard(354, partition, contiguous=True, keep_in_memory=True)
+
+        s = time.time()
+        # to make parallel GPU computations possible
+        try:
+            mp.set_start_method('spawn', force=True)
+        except RuntimeError:
+            pass
+
+        # number of processes depends on the number of GPUs available, can be varied
+        num_processes = torch.cuda.device_count() # TODO is this right?
+        tokenizer = M2M100Tokenizer.from_pretrained("facebook/m2m100_1.2B")
+
+        # target language
+        tokenizer.tgt_lang = "en"
+        model = M2M100ForConditionalGeneration.from_pretrained(
+            "facebook/m2m100_1.2B").to(device)
+        model.half()
+
+        # parallel model
+        model.share_memory()
+        processes = []
+        n_samples = len(shard)
+        c = int(n_samples/num_processes)
+        ranges = [[_, _+c] for _ in range(0, n_samples, c)]
+        for rank, rng in zip(range(num_processes), ranges):
+            start, end = rng
+            p = mp.Process(
+                target=translate_part,
+                args=[tokenizer, model, start, end, shard, DATA_DIR]
+            )
+            p.start()
+            processes.append(p)
+        
+        for p in processes:
+            p.join()
+        
+        # combining parquet files for every process in one file
+
+        fs = [pd.read_parquet(DATA_DIR+'/'+path) for path in os.listdir(DATA_DIR)]
+
+        DATA_DIR_TRANSLATED = f'{FINAL_DATA_DIR}/{url}'
+
+        if not os.path.exists(DATA_DIR_TRANSLATED):
+            os.makedirs(DATA_DIR_TRANSLATED)
+        
+        pd.concat(fs).to_parquet(f'{DATA_DIR_TRANSLATED}/{url}_{partition}.parquet')
+    
+        # remove the directories we don't need anymore
+        shutil.rmtree(DATA_DIR)
+
+        e = time.time()
+        print(f'Processed in {round(e-s, 2)} seconds')
+
+        client.completeJob()
+    
+    return 0
+
+
 if __name__ == '__main__':
-    dataset_name, data_files, start_rng, end_rng = sys.argv[1:]
-    start_rng, end_rng = int(start_rng), int(end_rng)
-
-    dataset = load_dataset(dataset_name,
-                           data_files=data_files)
-    # take desired part of the dataset
-    small_dataset = dataset["train"].select(
-        [i for i in range(start_rng, end_rng, 1)])
-    s = time.time()
-    # to make parallel GPU computations possible
-    try:
-        mp.set_start_method('spawn', force=True)
-    except RuntimeError:
-        pass
-    # number of processes depends on the number of GPUs available, can be varied
-    num_processes = 3
-    tokenizer = M2M100Tokenizer.from_pretrained("facebook/m2m100_1.2B")
-    # target language
-    tokenizer.tgt_lang = "en"
-    model = M2M100ForConditionalGeneration.from_pretrained(
-        "facebook/m2m100_1.2B").to(device)
-    model.half()
-    # parallel model
-    model.share_memory()
-    processes = []
-    n_samples = end_rng - start_rng
-    c = int(n_samples/num_processes)
-    ranges = [[_, _+c] for _ in range(0, n_samples, c)]
-    for rank, rng in zip(range(num_processes), ranges):
-        start, end = rng
-        p = mp.Process(target=translate_part, args=[
-                       tokenizer, model, start, end, small_dataset])
-        p.start()
-        processes.append(p)
-    for p in processes:
-        p.join()
-    # combining parquet files for every process in one file
-    fs = [pd.read_parquet(DATA_DIR+'/'+path) for path in os.listdir(DATA_DIR)]
-    DATA_DIR_TRANSLATED = f'{dataset_name}_{start_rng}_{end_rng}'
-    if not os.path.exists(DATA_DIR_TRANSLATED):
-        os.makedirs(DATA_DIR_TRANSLATED)
-    pd.concat(fs).to_parquet(f'{DATA_DIR_TRANSLATED}.parquet')
-    # remove the directories we don't need anymore
-    shutil.rmtree(DATA_DIR)
-    shutil.rmtree(DATA_DIR_TRANSLATED)
-
-    e = time.time()
-    print(f'Processed in {round(e-s, 2)} seconds')
+    exit(worker())


### PR DESCRIPTION
A few things to note:

I wasn't too sure what to enter as the `num_processes` value. Judging by the text above, I set it to the GPU count, however, it may be useful to check first (it was previously something like 2?):
```py
# number of processes depends on the number of GPUs available, can be varied
num_processes = torch.cuda.device_count()
```

I've settled on two constants that need to be edited to the appropriate directories before deploying:
```py
TMP_DATA_DIR = './DATA'
FINAL_DATA_DIR = './UPLOAD'
```

I believe these should be something like:
```py
TMP_DATA_DIR = '/tmp/translate-dataset/'
FINAL_DATA_DIR = '/fsx/translate-dataset/'
```
